### PR TITLE
Fix: Call selfClique even if not multi node clique

### DIFF
--- a/lib/clique.ts
+++ b/lib/clique.ts
@@ -32,13 +32,13 @@ export class CliqueClient extends Api<null> {
   async init(isMultiNodesClique: boolean) {
     this.clients = []
 
+    const res = await this.selfClique()
+
+    if (res.error) {
+      throw new Error(res.error.detail)
+    }
+
     if (isMultiNodesClique) {
-      const res = await this.selfClique()
-
-      if (res.error) {
-        throw new Error(res.error.detail)
-      }
-
       this.clique = res.data
 
       if (this.clique.nodes) {


### PR DESCRIPTION
For our clients to properly confirm if the connection to node is OK.