### PR TITLE
Get group from address

### DIFF
--- a/lib/address.ts
+++ b/lib/address.ts
@@ -15,9 +15,9 @@
 // along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 import bs58 from '../lib/bs58'
-import { djb2 } from '../lib/djb2'
+import djb2 from '../lib/djb2'
 
-export function addressToGroup(address: string, numberOfGroup: number): number {
+export default function addressToGroup(address: string, numberOfGroup: number): number {
   const bytes = bs58.decode(address).slice(1)
   const value = djb2(bytes) | 1
   const hash = toPosInt(xorByte(value))

--- a/lib/address.ts
+++ b/lib/address.ts
@@ -18,20 +18,20 @@ import bs58 from '../lib/bs58'
 import { djb2 } from '../lib/djb2'
 
 export function addressToGroup(address: string, numberOfGroup: number): number {
-  let bytes = bs58.decode(address).slice(1)
-  let value = djb2(bytes) | 1
-  let hash = toPosInt(xorByte(value))
-  let group = hash % numberOfGroup
+  const bytes = bs58.decode(address).slice(1)
+  const value = djb2(bytes) | 1
+  const hash = toPosInt(xorByte(value))
+  const group = hash % numberOfGroup
   return group
 }
 
 function xorByte(value: number): number {
-  var byte0 = value >> 24
-  var byte1 = value >> 16
-  var byte2 = value >> 8
+  const byte0 = value >> 24
+  const byte1 = value >> 16
+  const byte2 = value >> 8
   return byte0 ^ byte1 ^ byte2 ^ value
 }
 
-function toPosInt(byte: number): number  {
+function toPosInt(byte: number): number {
   return byte & 0xff
 }

--- a/lib/address.ts
+++ b/lib/address.ts
@@ -17,11 +17,11 @@
 import bs58 from '../lib/bs58'
 import { djb2 } from '../lib/djb2'
 
-export function addressToGroup(address: string): number {
+export function addressToGroup(address: string, numberOfGroup: number): number {
   let bytes = bs58.decode(address).slice(1)
   let value = djb2(bytes) | 1
   let hash = toPosInt(xorByte(value))
-  let group = hash % 4
+  let group = hash % numberOfGroup
   return group
 }
 

--- a/lib/address.ts
+++ b/lib/address.ts
@@ -1,0 +1,37 @@
+// Copyright 2018 - 2021 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+import bs58 from '../lib/bs58'
+import { djb2 } from '../lib/djb2'
+
+export function addressToGroup(address: string): number {
+  let bytes = bs58.decode(address).slice(1)
+  let value = djb2(bytes) | 1
+  let hash = toPosInt(xorByte(value))
+  let group = hash % 4
+  return group
+}
+
+function xorByte(value: number): number {
+  var byte0 = value >> 24
+  var byte1 = value >> 16
+  var byte2 = value >> 8
+  return byte0 ^ byte1 ^ byte2 ^ value
+}
+
+function toPosInt(byte: number): number  {
+  return byte & 0xff
+}

--- a/lib/address.ts
+++ b/lib/address.ts
@@ -17,11 +17,11 @@
 import bs58 from '../lib/bs58'
 import djb2 from '../lib/djb2'
 
-export default function addressToGroup(address: string, numberOfGroup: number): number {
+export default function addressToGroup(address: string, totalNumberOfGroups: number): number {
   const bytes = bs58.decode(address).slice(1)
   const value = djb2(bytes) | 1
   const hash = toPosInt(xorByte(value))
-  const group = hash % numberOfGroup
+  const group = hash % totalNumberOfGroups
   return group
 }
 

--- a/lib/djb2.ts
+++ b/lib/djb2.ts
@@ -1,0 +1,23 @@
+// Copyright 2018 - 2021 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+export function djb2(bytes: Buffer) {
+  var hash = 5381
+  for (let i = 0; i < bytes.length; i++) {
+    hash = ((hash << 5) + hash) + (bytes[i] & 0xFF)
+  }
+  return hash
+}

--- a/lib/djb2.ts
+++ b/lib/djb2.ts
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the library. If not, see <http://www.gnu.org/licenses/>.
 
-export function djb2(bytes: Buffer) {
+export default function djb2(bytes: Buffer) {
   let hash = 5381
   for (let i = 0; i < bytes.length; i++) {
     hash = (hash << 5) + hash + (bytes[i] & 0xff)

--- a/lib/djb2.ts
+++ b/lib/djb2.ts
@@ -15,9 +15,9 @@
 // along with the library. If not, see <http://www.gnu.org/licenses/>.
 
 export function djb2(bytes: Buffer) {
-  var hash = 5381
+  let hash = 5381
   for (let i = 0; i < bytes.length; i++) {
-    hash = ((hash << 5) + hash) + (bytes[i] & 0xFF)
+    hash = (hash << 5) + hash + (bytes[i] & 0xff)
   }
   return hash
 }

--- a/test/address-test.ts
+++ b/test/address-test.ts
@@ -18,31 +18,28 @@ import { addressToGroup } from '../lib/address'
 
 describe('address', function () {
   it('should derive group', async () => {
-
     function check(address: string, expected: number) {
-      let group = addressToGroup(address, 4)
+      const group = addressToGroup(address, 4)
       expect(group).toEqual(expected)
     }
 
-    check("12psscGPMgdqctaeCA37HYAkpVBFX1LbN4dSvjyxbDyKk", 1)
-    check("16TGLiD3fqyuGFRFHffh58BC3okYCbjRH1WHPzeSp39Wi", 2)
-    check("15aTcpJfCX9akQqYuRMMgun6Mv6ek8bigB98VTUFMwKYA", 1)
-    check("164ejvnxGYRPUt3tYwJrMxBLLmeag2WACH4GfcsRUN3W7", 2)
-    check("15p5vK921GnxFSQgXZo8Wceg6EvwcXZ9rCQxE2SeXc1s5", 1)
-    check("1HSLAetSuMTKPHukvXYg6yaDuUJ67vxGashzFLEuu6qV6", 1)
-    check("1HbU1TDiUMAj33Cp5cA2xc9uTqp1bjWa5UvkeGLm4bDbE", 2)
-    check("13zn4s3fb5Q9d8rtszYdmYVpQ3MM9VM2xLBe9rMhcNxjd", 0)
-    check("1DdQwce5ZzFrEYyz1H5KU9v8hRpoTbq5i7zE5Nu5k4ope", 2)
-    check("19hpcUVGzdpWRD8yVUyP9pJwwxD6P5ixGUgSmVPbhBAVX", 2)
-    check("1DpNeY8uutS1FRW7D565WjUgu5HcKSYAMqZNWgUJWggWZ", 0)
-    check("1G1gjpt4mxij7JwP5SpX6ScwQHisWN3V5WBtFfWKtc3vo", 3)
-    check("19XyGb6f1upjvQAG4vexB1EmY3pU8G2VN5gM267Pdhogg", 3)
-    check("1H5YniQrUqxJY9ShTjMeX6DMgjPpYfdFqDvTgBYv6h1iz", 1)
-    check("18Ca9jZDqRcxTfdNr2hq5KBJjf7PJLA5PXMjRoeB83JNv", 3)
-    check("15XyPNJuZ85wyUMs4mwn98LLPMjiwUSCuTmR74NuxpwXT", 0)
-    check("1F6ssQRwH1p1omaoQR3eirFrycHC3mUr3Vw9pLcgEe33W", 1)
-    check("19JtVnQ4YLcA9mWPafnLmtWarAjdaLR3d7R5RAUjxHbe1", 3)
-
+    check('12psscGPMgdqctaeCA37HYAkpVBFX1LbN4dSvjyxbDyKk', 1)
+    check('16TGLiD3fqyuGFRFHffh58BC3okYCbjRH1WHPzeSp39Wi', 2)
+    check('15aTcpJfCX9akQqYuRMMgun6Mv6ek8bigB98VTUFMwKYA', 1)
+    check('164ejvnxGYRPUt3tYwJrMxBLLmeag2WACH4GfcsRUN3W7', 2)
+    check('15p5vK921GnxFSQgXZo8Wceg6EvwcXZ9rCQxE2SeXc1s5', 1)
+    check('1HSLAetSuMTKPHukvXYg6yaDuUJ67vxGashzFLEuu6qV6', 1)
+    check('1HbU1TDiUMAj33Cp5cA2xc9uTqp1bjWa5UvkeGLm4bDbE', 2)
+    check('13zn4s3fb5Q9d8rtszYdmYVpQ3MM9VM2xLBe9rMhcNxjd', 0)
+    check('1DdQwce5ZzFrEYyz1H5KU9v8hRpoTbq5i7zE5Nu5k4ope', 2)
+    check('19hpcUVGzdpWRD8yVUyP9pJwwxD6P5ixGUgSmVPbhBAVX', 2)
+    check('1DpNeY8uutS1FRW7D565WjUgu5HcKSYAMqZNWgUJWggWZ', 0)
+    check('1G1gjpt4mxij7JwP5SpX6ScwQHisWN3V5WBtFfWKtc3vo', 3)
+    check('19XyGb6f1upjvQAG4vexB1EmY3pU8G2VN5gM267Pdhogg', 3)
+    check('1H5YniQrUqxJY9ShTjMeX6DMgjPpYfdFqDvTgBYv6h1iz', 1)
+    check('18Ca9jZDqRcxTfdNr2hq5KBJjf7PJLA5PXMjRoeB83JNv', 3)
+    check('15XyPNJuZ85wyUMs4mwn98LLPMjiwUSCuTmR74NuxpwXT', 0)
+    check('1F6ssQRwH1p1omaoQR3eirFrycHC3mUr3Vw9pLcgEe33W', 1)
+    check('19JtVnQ4YLcA9mWPafnLmtWarAjdaLR3d7R5RAUjxHbe1', 3)
   })
 })
-

--- a/test/address-test.ts
+++ b/test/address-test.ts
@@ -1,0 +1,48 @@
+// Copyright 2018 - 2021 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+import { addressToGroup } from '../lib/address'
+
+describe('address', function () {
+  it('should derive group', async () => {
+
+    function check(address: string, expected: number) {
+      let group = addressToGroup(address)
+      expect(group).toEqual(expected)
+    }
+
+    check("12psscGPMgdqctaeCA37HYAkpVBFX1LbN4dSvjyxbDyKk", 1)
+    check("16TGLiD3fqyuGFRFHffh58BC3okYCbjRH1WHPzeSp39Wi", 2)
+    check("15aTcpJfCX9akQqYuRMMgun6Mv6ek8bigB98VTUFMwKYA", 1)
+    check("164ejvnxGYRPUt3tYwJrMxBLLmeag2WACH4GfcsRUN3W7", 2)
+    check("15p5vK921GnxFSQgXZo8Wceg6EvwcXZ9rCQxE2SeXc1s5", 1)
+    check("1HSLAetSuMTKPHukvXYg6yaDuUJ67vxGashzFLEuu6qV6", 1)
+    check("1HbU1TDiUMAj33Cp5cA2xc9uTqp1bjWa5UvkeGLm4bDbE", 2)
+    check("13zn4s3fb5Q9d8rtszYdmYVpQ3MM9VM2xLBe9rMhcNxjd", 0)
+    check("1DdQwce5ZzFrEYyz1H5KU9v8hRpoTbq5i7zE5Nu5k4ope", 2)
+    check("19hpcUVGzdpWRD8yVUyP9pJwwxD6P5ixGUgSmVPbhBAVX", 2)
+    check("1DpNeY8uutS1FRW7D565WjUgu5HcKSYAMqZNWgUJWggWZ", 0)
+    check("1G1gjpt4mxij7JwP5SpX6ScwQHisWN3V5WBtFfWKtc3vo", 3)
+    check("19XyGb6f1upjvQAG4vexB1EmY3pU8G2VN5gM267Pdhogg", 3)
+    check("1H5YniQrUqxJY9ShTjMeX6DMgjPpYfdFqDvTgBYv6h1iz", 1)
+    check("18Ca9jZDqRcxTfdNr2hq5KBJjf7PJLA5PXMjRoeB83JNv", 3)
+    check("15XyPNJuZ85wyUMs4mwn98LLPMjiwUSCuTmR74NuxpwXT", 0)
+    check("1F6ssQRwH1p1omaoQR3eirFrycHC3mUr3Vw9pLcgEe33W", 1)
+    check("19JtVnQ4YLcA9mWPafnLmtWarAjdaLR3d7R5RAUjxHbe1", 3)
+
+  })
+})
+

--- a/test/address-test.ts
+++ b/test/address-test.ts
@@ -20,7 +20,7 @@ describe('address', function () {
   it('should derive group', async () => {
 
     function check(address: string, expected: number) {
-      let group = addressToGroup(address)
+      let group = addressToGroup(address, 4)
       expect(group).toEqual(expected)
     }
 

--- a/test/address-test.ts
+++ b/test/address-test.ts
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the library. If not, see <http://www.gnu.org/licenses/>.
 
-import { addressToGroup } from '../lib/address'
+import addressToGroup from '../lib/address'
 
 describe('address', function () {
   it('should derive group', async () => {

--- a/test/djb2-test.ts
+++ b/test/djb2-test.ts
@@ -1,0 +1,33 @@
+// Copyright 2018 - 2021 The Alephium Authors
+// This file is part of the alephium project.
+//
+// The library is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Lesser General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// The library is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU Lesser General Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License
+// along with the library. If not, see <http://www.gnu.org/licenses/>.
+
+import { djb2 } from '../lib/djb2'
+
+describe('djb2', function () {
+  it('djb2', async () => {
+
+    function check(str: string, expected: number) {
+      let bytes = Buffer.from(str, 'utf8');
+      expect(djb2(bytes)).toEqual(expected)
+    }
+
+    check("", 5381)
+    check("a", 177670)
+    check("z", 177695)
+    check("foo", 193491849)
+    check("bar", 193487034)
+  })
+})

--- a/test/djb2-test.ts
+++ b/test/djb2-test.ts
@@ -18,16 +18,15 @@ import { djb2 } from '../lib/djb2'
 
 describe('djb2', function () {
   it('djb2', async () => {
-
     function check(str: string, expected: number) {
-      let bytes = Buffer.from(str, 'utf8');
+      const bytes = Buffer.from(str, 'utf8')
       expect(djb2(bytes)).toEqual(expected)
     }
 
-    check("", 5381)
-    check("a", 177670)
-    check("z", 177695)
-    check("foo", 193491849)
-    check("bar", 193487034)
+    check('', 5381)
+    check('a', 177670)
+    check('z', 177695)
+    check('foo', 193491849)
+    check('bar', 193487034)
   })
 })

--- a/test/djb2-test.ts
+++ b/test/djb2-test.ts
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the library. If not, see <http://www.gnu.org/licenses/>.
 
-import { djb2 } from '../lib/djb2'
+import djb2 from '../lib/djb2'
 
 describe('djb2', function () {
   it('djb2', async () => {


### PR DESCRIPTION
@mvaivre @nop33 That's maybe not the best way to export the function, let me know what it the best to do.

That could maybe be nice to have an `Address` type/class that we could reuse over our repos? but as you will mostly use it I'll let you decide.

Here is the various reference in `alephium`:
https://github.com/alephium/alephium/blob/6faf1fbc5a7bf13b4fd164f5e4876d57387edebf/protocol/src/main/scala/org/alephium/protocol/vm/LockupScript.scala#L36-L44
https://github.com/alephium/alephium/blob/6faf1fbc5a7bf13b4fd164f5e4876d57387edebf/protocol/src/main/scala/org/alephium/protocol/model/ScriptHint.scala#L23-L38
https://github.com/alephium/alephium/blob/6faf1fbc5a7bf13b4fd164f5e4876d57387edebf/util/src/main/scala/org/alephium/util/DjbHash.scala#L21-L27
https://github.com/alephium/alephium/blob/6faf1fbc5a7bf13b4fd164f5e4876d57387edebf/util/src/main/scala/org/alephium/util/Bytes.scala#L62-L68
https://github.com/alephium/alephium/blob/6faf1fbc5a7bf13b4fd164f5e4876d57387edebf/util/src/main/scala/org/alephium/util/Bytes.scala#L24-L26