### PR TITLE
Display only 2 decimals when value is 0

### DIFF
--- a/lib/numbers.ts
+++ b/lib/numbers.ts
@@ -65,7 +65,7 @@ export const abbreviateAmount = (baseNum: bigint, showFullPrecision = false, nbO
 
   // For abbreviation, we don't need full precision and can work with number
   const alphNum = Number(baseNum) / QUINTILLION
-  const minNumberOfDecimals = alphNum < 0.01 ? 3 : 2
+  const minNumberOfDecimals = alphNum >= 0.000005 && alphNum < 0.01 ? 3 : 2
 
   if (showFullPrecision) {
     const decimals = countDecimals(alphNum) === 1 ? 16 : 18 // Avoid precision issue edge case

--- a/package-lock.json
+++ b/package-lock.json
@@ -6088,9 +6088,9 @@
       "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
     "node_modules/nanoid": {
-      "version": "3.1.30",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -6115,15 +6115,23 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
       "engines": {
         "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/node-fetch-h2": {
@@ -12576,9 +12584,9 @@
       "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
     },
     "nanoid": {
-      "version": "3.1.30",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
       "dev": true
     },
     "natural-compare": {
@@ -12597,9 +12605,9 @@
       }
     },
     "node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
       "dev": true,
       "requires": {
         "whatwg-url": "^5.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "alephium-js",
-      "version": "1.0.7",
+      "version": "1.0.8",
       "license": "GPL",
       "dependencies": {
         "base-x": "^3.0.8",

--- a/test/numbers-test.ts
+++ b/test/numbers-test.ts
@@ -34,11 +34,13 @@ const minDigits = 3
 
 it('Should abbreviate amount', () => {
   expect(abbreviateAmount(alph(BigInt(-1)))).toEqual('???'),
-    expect(abbreviateAmount(BigInt(0))).toEqual('0.000'),
-    expect(abbreviateAmount(BigInt(1))).toEqual('0.000'),
-    expect(abbreviateAmount(BigInt(100000))).toEqual('0.000'),
-    expect(abbreviateAmount(BigInt(1000000000))).toEqual('0.000'),
-    expect(abbreviateAmount(BigInt(2000000000))).toEqual('0.000'),
+    expect(abbreviateAmount(BigInt(0))).toEqual('0.00'),
+    expect(abbreviateAmount(BigInt(1))).toEqual('0.00'),
+    expect(abbreviateAmount(BigInt(100000))).toEqual('0.00'),
+    expect(abbreviateAmount(BigInt(900000000000))).toEqual('0.00'),
+    expect(abbreviateAmount(BigInt(4000000000000))).toEqual('0.00'),
+    expect(abbreviateAmount(BigInt(5000000000000))).toEqual('0.00001'),
+    expect(abbreviateAmount(BigInt(6000000000000))).toEqual('0.00001'),
     expect(abbreviateAmount(BigInt(2000000000000000))).toEqual('0.002'),
     expect(abbreviateAmount(BigInt('20000000000000000'))).toEqual('0.02'),
     expect(abbreviateAmount(BigInt('200000000000000000'))).toEqual('0.2'),
@@ -56,7 +58,7 @@ it('Should abbreviate amount', () => {
 
 it('Should keep full amount precision', () => {
   expect(abbreviateAmount(alph(BigInt(-1)))).toEqual('???'),
-    expect(abbreviateAmount(BigInt(0), true)).toEqual('0.000'),
+    expect(abbreviateAmount(BigInt(0), true)).toEqual('0.00'),
     expect(abbreviateAmount(BigInt(1), true)).toEqual('0.000000000000000001'),
     expect(abbreviateAmount(BigInt(100001), true)).toEqual('0.000000000000100001'),
     expect(abbreviateAmount(BigInt(1000000000), true)).toEqual('0.000000001'),


### PR DESCRIPTION
Since we [agreed](https://github.com/alephium/alephium-wallet/issues/116#issuecomment-1016179165) that amounts <= `0.001` are rounded up to the 5th decimal point, anything < `0.000005` should be displayed as `0.00` and not `0.000` (since `0.000005` is rounded to `0.00001` which has 5 decimal points).